### PR TITLE
fix some bugs

### DIFF
--- a/model/log_test.go
+++ b/model/log_test.go
@@ -30,9 +30,9 @@ func TestGetAllLogsRetryFilter(t *testing.T) {
 
 	got, total, err := GetAllLogs(LogTypeUnknown, LogFilterRetry, 0, 0, "", "", "", 0, 10, 0, "", "", "")
 	require.NoError(t, err)
-	require.EqualValues(t, 2, total)
-	require.Len(t, got, 2)
-	require.ElementsMatch(t, []int{logs[0].Id, logs[1].Id}, []int{got[0].Id, got[1].Id})
+	require.EqualValues(t, 3, total)
+	require.Len(t, got, 3)
+	require.ElementsMatch(t, []int{logs[0].Id, logs[1].Id, logs[4].Id}, []int{got[0].Id, got[1].Id, got[2].Id})
 }
 
 func TestGetUserLogsRetryFilter(t *testing.T) {
@@ -48,6 +48,9 @@ func TestGetUserLogsRetryFilter(t *testing.T) {
 	require.EqualValues(t, 2, total)
 	require.Len(t, got, 2)
 	require.ElementsMatch(t, []int{logs[0].Id, logs[1].Id}, []int{got[0].LogId, got[1].LogId})
+	for _, log := range got {
+		require.Equal(t, 1, log.UserId)
+	}
 }
 
 func TestSumUsedQuotaRetryFilter(t *testing.T) {
@@ -60,9 +63,9 @@ func TestSumUsedQuotaRetryFilter(t *testing.T) {
 
 	stat, err := SumUsedQuota(LogTypeUnknown, LogFilterRetry, 0, 0, "", "", "", 0, "")
 	require.NoError(t, err)
-	require.Equal(t, 300, stat.Quota)
-	require.Equal(t, 2, stat.Rpm)
-	require.Equal(t, 30, stat.Tpm)
+	require.Equal(t, 1200, stat.Quota)
+	require.Equal(t, 3, stat.Rpm)
+	require.Equal(t, 71, stat.Tpm)
 }
 
 func createRetryFilterLogs(t *testing.T) []Log {
@@ -121,6 +124,20 @@ func createRetryFilterLogs(t *testing.T) []Log {
 			Other: common.MapToJsonStr(map[string]interface{}{
 				"admin_info": map[string]interface{}{
 					"use_channel": []string{"5"},
+				},
+			}),
+		},
+		{
+			UserId:           2,
+			CreatedAt:        time.Now().Unix() - 50,
+			Type:             LogTypeConsume,
+			Quota:            900,
+			PromptTokens:     23,
+			CompletionTokens: 18,
+			Other: common.MapToJsonStr(map[string]interface{}{
+				"retry_log": true,
+				"admin_info": map[string]interface{}{
+					"use_channel": []string{"6", "7"},
 				},
 			}),
 		},


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
补强使用日志 `retry` 筛选的回归测试覆盖。

本次在 retry 筛选测试数据中新增了一条属于其他用户的 `retry_log` 日志，并更新 `GetUserLogs` 断言，确保用户日志查询在应用 retry 条件时仍然保留 `user_id` 作用域，不会把其他用户的重试日志返回给当前用户。同时同步调整全局日志查询与统计查询的预期值，使测试数据覆盖全局 retry 筛选和用户级 retry 筛选两种路径。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [x] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/MAX-API-Next/MAX-API/issues) 与 [PRs](https://github.com/MAX-API-Next/MAX-API/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```text
go test ./model -run "Test(GetAllLogsRetryFilter|GetUserLogsRetryFilter|SumUsedQuotaRetryFilter)$"
ok  	github.com/MAX-API-Next/MAX-API/model	12.220s

bun test src/features/usage-logs/lib/utils.test.ts
6 pass
0 fail

git diff --check
# no output