### PR TITLE
v1.0.4-preview.1

### DIFF
--- a/web/default/src/components/ai-elements/prompt-input.tsx
+++ b/web/default/src/components/ai-elements/prompt-input.tsx
@@ -888,7 +888,10 @@ export const PromptInputTextarea = ({
 
   return (
     <InputGroupTextarea
-      className={cn('field-sizing-content max-h-48 min-h-16', className)}
+      className={cn(
+        'field-sizing-content max-h-48 min-h-16 min-w-0 max-w-full [overflow-wrap:anywhere]',
+        className
+      )}
       name='message'
       onCompositionEnd={() => setIsComposing(false)}
       onCompositionStart={() => setIsComposing(true)}

--- a/web/default/src/components/model-group-selector.tsx
+++ b/web/default/src/components/model-group-selector.tsx
@@ -92,6 +92,7 @@ const ModelTriggerButton = React.forwardRef<
       'flex h-8 items-center gap-2 border px-3 font-medium',
       'justify-center p-0 sm:w-auto sm:justify-start sm:px-3',
       'w-8',
+      'min-w-0 sm:max-w-48 md:max-w-64',
       'bg-background text-foreground',
       'hover:bg-accent transition-colors',
       'focus:!ring-0 focus:!outline-none',
@@ -128,6 +129,7 @@ const GroupTriggerButton = React.forwardRef<
       'flex h-8 items-center gap-2 border px-3 font-medium',
       'justify-center p-0 sm:w-auto sm:justify-start sm:px-3',
       'w-8',
+      'min-w-0 sm:max-w-40 md:max-w-52',
       'bg-background text-foreground',
       'hover:bg-accent transition-colors',
       'focus:!ring-0 focus:!outline-none',
@@ -569,7 +571,7 @@ export const ModelGroupSelector: React.FC<ModelGroupSelectorProps> = ({
   disabled = false,
 }) => {
   return (
-    <div className={cn('flex items-center gap-2', className)}>
+    <div className={cn('flex min-w-0 items-center gap-2', className)}>
       <GroupSelector
         selectedGroup={selectedGroup}
         groups={groups}

--- a/web/default/src/components/ui/input-group.tsx
+++ b/web/default/src/components/ui/input-group.tsx
@@ -156,7 +156,7 @@ function InputGroupTextarea({
     <Textarea
       data-slot='input-group-control'
       className={cn(
-        'flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent',
+        'min-w-0 max-w-full flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent',
         className
       )}
       {...props}

--- a/web/default/src/features/playground/components/playground-input.tsx
+++ b/web/default/src/features/playground/components/playground-input.tsx
@@ -141,8 +141,8 @@ export function PlaygroundInput({
           value={text}
         />
 
-        <PromptInputFooter className='p-2.5'>
-          <PromptInputTools>
+        <PromptInputFooter className='flex-wrap p-2.5'>
+          <PromptInputTools className='min-w-0 flex-wrap'>
             <DropdownMenu>
               <DropdownMenuTrigger
                 render={
@@ -222,8 +222,9 @@ export function PlaygroundInput({
             </TooltipProvider>
           </PromptInputTools>
 
-          <div className='flex items-center gap-1.5 md:gap-2'>
+          <div className='ml-auto flex min-w-0 items-center gap-1.5 md:gap-2'>
             <ModelGroupSelector
+              className='min-w-0'
               selectedModel={modelValue}
               models={models}
               onModelChange={onModelChange}
@@ -235,7 +236,7 @@ export function PlaygroundInput({
 
             {isGenerating && onStop ? (
               <PromptInputButton
-                className='text-foreground font-medium'
+                className='text-foreground shrink-0 font-medium'
                 onClick={onStop}
                 variant='secondary'
               >
@@ -245,7 +246,7 @@ export function PlaygroundInput({
               </PromptInputButton>
             ) : (
               <PromptInputButton
-                className='text-foreground font-medium'
+                className='text-foreground shrink-0 font-medium'
                 disabled={disabled || isSubmitDisabled || !text.trim()}
                 type='submit'
                 variant='secondary'


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

修复 Playground 输入区在输入连续超长文本时的横向溢出问题。

原因是输入框内容会参与自身宽度计算，遇到没有空格的长字符串时，textarea 和底部工具栏可能被撑宽，进而把模型 / 分组配置入口和发送按钮挤到屏幕外。本次调整让输入框在容器内换行并允许 flex 子项正常收缩，同时限制模型 / 分组选择器的最大宽度，底部操作区在窄屏下也可以换行，因此长提示词不会再破坏整体布局。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # 无公开 Issue，来自 Playground 长文本输入布局问题反馈

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/MAX-API-Next/MAX-API/issues) 与 [PRs](https://github.com/MAX-API-Next/MAX-API/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

- `bun run typecheck` 通过
- `bun run build` 通过
- `git diff --check` 通过
- Headless Chrome 手动布局验证通过：
  - `/playground/`
  - 输入 4000 个连续字符
  - 390px 视口无横向溢出，发送按钮仍在输入框内
  - 1280px 视口无横向溢出，发送按钮仍在输入框内